### PR TITLE
Tests and fixes

### DIFF
--- a/lib/get-config-path.test.js
+++ b/lib/get-config-path.test.js
@@ -1,0 +1,29 @@
+'use strict'
+
+const getConfigPath = require('./get-config-path')
+const findConfig = require('./find-config')
+
+jest.mock('./find-config')
+
+/** @type {Object} */
+const mockFindConfig = findConfig
+
+describe('get-config-path', () => {
+  it('returns a config path', () => {
+    mockFindConfig.mockImplementation(() => ({
+      filepath: 'my/file/path.txt',
+    }))
+
+    const result = getConfigPath('babel')
+
+    expect(result).toBe('my/file/path.txt')
+  })
+
+  it('returns null if no config is found', () => {
+    mockFindConfig.mockImplementation(() => null)
+
+    const result = getConfigPath('webpack')
+
+    expect(result).toBeNull()
+  })
+})

--- a/lib/get-config.test.js
+++ b/lib/get-config.test.js
@@ -1,0 +1,30 @@
+'use strict'
+
+const getConfig = require('./get-config')
+const findConfig = require('./find-config')
+
+jest.mock('./find-config')
+
+/** @type {Object} */
+const mockFindConfig = findConfig
+
+describe('get-config', () => {
+  it('returns a config', () => {
+    const mockConfig = { test: true }
+    mockFindConfig.mockImplementation(() => ({
+      config: mockConfig,
+    }))
+
+    const result = getConfig('prettier')
+
+    expect(result).toEqual(mockConfig)
+  })
+
+  it('returns null if no config is found', () => {
+    mockFindConfig.mockImplementation(() => null)
+
+    const result = getConfig('prettier')
+
+    expect(result).toBeNull()
+  })
+})

--- a/lib/get-ignore-path.test.js
+++ b/lib/get-ignore-path.test.js
@@ -1,0 +1,29 @@
+'use strict'
+
+const getIgnorePath = require('./get-ignore-path')
+const findConfig = require('./find-config')
+
+jest.mock('./find-config')
+
+/** @type {Object} */
+const mockFindConfig = findConfig
+
+describe('get-ignore-path', () => {
+  it('returns an ignore path', () => {
+    mockFindConfig.mockImplementation(() => ({
+      filepath: 'my/file/.gitignore',
+    }))
+
+    const result = getIgnorePath('.gitignore')
+
+    expect(result).toBe('my/file/.gitignore')
+  })
+
+  it('returns null if no ignore path is found', () => {
+    mockFindConfig.mockImplementation(() => null)
+
+    const result = getIgnorePath('.prettierignore')
+
+    expect(result).toBeNull()
+  })
+})

--- a/lib/merge-args.js
+++ b/lib/merge-args.js
@@ -16,7 +16,7 @@ const unparse = require('yargs-unparser')
  * // returns ['--silent', '--pass-with-no-tests']
  */
 function mergeArgs(args, options) {
-  return unparse(parse(args, options), { alias: options.alias })
+  return unparse(parse(args, options), { alias: options.alias || {} })
 }
 
 module.exports = mergeArgs

--- a/lib/merge-args.js
+++ b/lib/merge-args.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const debug = require('debug')('cli-rewire:merge-args')
 const parse = require('yargs-parser')
 const unparse = require('yargs-unparser')
 
@@ -16,7 +17,10 @@ const unparse = require('yargs-unparser')
  * // returns ['--silent', '--pass-with-no-tests']
  */
 function mergeArgs(args, options) {
-  return unparse(parse(args, options), { alias: options.alias || {} })
+  debug('start %o %o', args, options)
+  const merged = unparse(parse(args, options), { alias: options.alias || {} })
+  debug('end %o', merged)
+  return merged
 }
 
 module.exports = mergeArgs

--- a/lib/merge-args.test.js
+++ b/lib/merge-args.test.js
@@ -1,0 +1,96 @@
+'use strict'
+
+const mergeArgs = require('./merge-args')
+
+describe('merge-args', () => {
+  it.each([
+    // Should merge default options with args
+    [
+      ['--silent'],
+      { default: { passWithNoTests: true } },
+      ['--silent', '--pass-with-no-tests'],
+    ],
+
+    // Should merged default options with args
+    [
+      ['--fix', '.'],
+      {
+        alias: {
+          config: 'c',
+          format: 'f',
+        },
+        default: {
+          cache: true,
+          config: '/my/path/to/config.js',
+          ext: ['.js', '.jsx', '.json'],
+        },
+      },
+      [
+        '--fix',
+        '.',
+        '--cache',
+        '--config',
+        '/my/path/to/config.js',
+        '--ext',
+        '.js',
+        '--ext',
+        '.jsx',
+        '--ext',
+        '.json',
+      ],
+    ],
+
+    // Should merged default options with args, even when args is empty
+    [
+      [],
+      {
+        alias: { config: 'c' },
+        default: {
+          config: '/path/to/config/file.js',
+          passWithNoTests: true,
+          silent: true,
+        },
+      },
+      [
+        '--config',
+        '/path/to/config/file.js',
+        '--pass-with-no-tests',
+        '--silent',
+      ],
+    ],
+
+    // Shouldn't break if args and options are empty
+    [[], {}, []],
+
+    // Should return args when options is empty
+    [['--config', 'my/config.js'], {}, ['--config', 'my/config.js']],
+
+    // Arg values should take precedence over default options
+    [
+      ['--config', 'my/config.js'],
+      {
+        default: {
+          config: 'path/to/config/file.js',
+          silent: true,
+        },
+      },
+      ['--config', 'my/config.js', '--silent'],
+    ],
+
+    // Aliased arg values should take precedence over default options
+    [
+      ['-c', 'my/config.js'],
+      {
+        alias: { config: 'c' },
+        default: {
+          config: 'path/to/config/file.js',
+          passWithNoTests: true,
+        },
+      },
+      ['--config', 'my/config.js', '--pass-with-no-tests'],
+    ],
+  ])('merges args %j with options %j', (args, options, expected) => {
+    const result = mergeArgs(args, options)
+    expect(result).toEqual(expected)
+  })
+})

--- a/lib/run-with-yargs.test.js
+++ b/lib/run-with-yargs.test.js
@@ -1,0 +1,54 @@
+'use strict'
+
+const runWithYargs = require('./run-with-yargs')
+const run = require('./run')
+
+jest.mock('./run')
+
+/** @type {Object} */
+const mockRun = run
+
+describe('run-with-yargs', () => {
+  const ARGV = process.argv
+  beforeEach(() => {
+    jest.resetModules()
+    process.argv = [...ARGV]
+  })
+
+  afterAll(() => {
+    process.argv = ARGV
+  })
+
+  it('runs with args', async () => {
+    mockRun.mockImplementation(() => Promise.resolve(0))
+    process.argv = ['node', 'file.js', '--write', '.']
+    const args = {
+      alias: {
+        config: 'c',
+        format: 'f',
+      },
+      default: {
+        cache: true,
+      },
+    }
+
+    await expect(runWithYargs('prettier', args)).resolves.toBe(0)
+    expect(mockRun).toHaveBeenCalledWith(
+      'prettier',
+      expect.arrayContaining(['--write', '.', '--cache']),
+      {}
+    )
+  })
+
+  it('runs with no args', async () => {
+    mockRun.mockImplementation(() => Promise.resolve(0))
+    process.argv = ['node', 'file.js', '--pass-with-no-tests', '--silent']
+
+    await expect(runWithYargs('jest')).resolves.toBe(0)
+    expect(mockRun).toHaveBeenCalledWith(
+      'jest',
+      expect.arrayContaining(['--pass-with-no-tests', '--silent']),
+      {}
+    )
+  })
+})

--- a/lib/run.test.js
+++ b/lib/run.test.js
@@ -39,6 +39,15 @@ describe('run', () => {
     )
   })
 
+  it('calls execa with no args', async () => {
+    mockExeca.mockImplementation(() => buildReturnValue({ exitCode: 0 }))
+    const cmd = 'prettier'
+
+    const result = await run(cmd)
+    expect(result).toBe(0)
+    expect(mockExeca).toHaveBeenLastCalledWith(cmd, [], expect.anything())
+  })
+
   it('returns failure exit code on execa failure', async () => {
     mockExeca.mockImplementation(() => Promise.reject(new Error('error')))
     const cmd = 'echo'

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Make a CLI by rewiring other CLIs",
   "main": "index.js",
   "scripts": {
-    "test": "u test ci"
+    "test": "u test ci",
+    "test-local": "u test"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
- merge-args: default options.alias to an empty object; add tests and logging
- add tests for get-config, get-config-path, get-ignore-path, run-with-yargs
- add `npm run test-local`
