### PR TITLE
Env

### DIFF
--- a/lib/__tests__/find-config.test.js
+++ b/lib/__tests__/find-config.test.js
@@ -13,7 +13,7 @@ describe('find-config', () => {
     const cosmiconfig = require('cosmiconfig')
     cosmiconfig.cosmiconfigSync.mockReturnValue({ search })
 
-    const findConfig = require('./find-config')
+    const findConfig = require('../find-config')
     const result = findConfig('babel')
 
     expect(cosmiconfig.cosmiconfigSync).toHaveBeenCalledWith('babel', {})
@@ -29,7 +29,7 @@ describe('find-config', () => {
     const cosmiconfig = require('cosmiconfig')
     cosmiconfig.cosmiconfigSync.mockReturnValue({ search })
 
-    const findConfig = require('./find-config')
+    const findConfig = require('../find-config')
     const result = findConfig('eslint')
 
     expect(cosmiconfig.cosmiconfigSync).toHaveBeenCalledWith('eslint', {})
@@ -46,7 +46,7 @@ describe('find-config', () => {
     const cosmiconfig = require('cosmiconfig')
     cosmiconfig.cosmiconfigSync.mockReturnValue({ load, search })
 
-    const findConfig = require('./find-config')
+    const findConfig = require('../find-config')
     const result = findConfig('jest', {}, 'path/to/jest.config.js')
 
     expect(cosmiconfig.cosmiconfigSync).toHaveBeenCalledWith('jest', {})

--- a/lib/__tests__/get-config-path.test.js
+++ b/lib/__tests__/get-config-path.test.js
@@ -1,9 +1,9 @@
 'use strict'
 
-const getConfigPath = require('./get-config-path')
-const findConfig = require('./find-config')
+const getConfigPath = require('../get-config-path')
+const findConfig = require('../find-config')
 
-jest.mock('./find-config')
+jest.mock('../find-config')
 
 /** @type {Object} */
 const mockFindConfig = findConfig

--- a/lib/__tests__/get-config.test.js
+++ b/lib/__tests__/get-config.test.js
@@ -1,9 +1,9 @@
 'use strict'
 
-const getConfig = require('./get-config')
-const findConfig = require('./find-config')
+const getConfig = require('../get-config')
+const findConfig = require('../find-config')
 
-jest.mock('./find-config')
+jest.mock('../find-config')
 
 /** @type {Object} */
 const mockFindConfig = findConfig

--- a/lib/__tests__/get-ignore-path.test.js
+++ b/lib/__tests__/get-ignore-path.test.js
@@ -1,9 +1,9 @@
 'use strict'
 
-const getIgnorePath = require('./get-ignore-path')
-const findConfig = require('./find-config')
+const getIgnorePath = require('../get-ignore-path')
+const findConfig = require('../find-config')
 
-jest.mock('./find-config')
+jest.mock('../find-config')
 
 /** @type {Object} */
 const mockFindConfig = findConfig

--- a/lib/__tests__/index.test.js
+++ b/lib/__tests__/index.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const index = require('.')
+const index = require('..')
 
 describe('index', () => {
   it('is defined', () => {

--- a/lib/__tests__/messages.test.js
+++ b/lib/__tests__/messages.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const messages = require('./messages')
+const messages = require('../messages')
 
 describe('messages', () => {
   it('is defined', () => {

--- a/lib/__tests__/parse-script.test.js
+++ b/lib/__tests__/parse-script.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const parseScript = require('./parse-script')
+const parseScript = require('../parse-script')
 
 describe('parse-script', () => {
   it.each([

--- a/lib/__tests__/parse-scripts.test.js
+++ b/lib/__tests__/parse-scripts.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const parseScripts = require('./parse-scripts')
+const parseScripts = require('../parse-scripts')
 
 const scriptMap = {
   a: 'path/to/a',

--- a/lib/__tests__/rewire-args.test.js
+++ b/lib/__tests__/rewire-args.test.js
@@ -2,7 +2,7 @@
 
 /* eslint-disable max-params */
 
-const rewireArgs = require('./rewire-args')
+const rewireArgs = require('../rewire-args')
 
 test.each([
   // Should apply default options to args

--- a/lib/__tests__/rewire.test.js
+++ b/lib/__tests__/rewire.test.js
@@ -1,9 +1,9 @@
 'use strict'
 
-const rewire = require('./rewire')
-const run = require('./run')
+const rewire = require('../rewire')
+const run = require('../run')
 
-jest.mock('./run')
+jest.mock('../run')
 
 const ARGV = process.argv
 

--- a/lib/__tests__/run-script.test.js
+++ b/lib/__tests__/run-script.test.js
@@ -2,10 +2,10 @@
 
 /* eslint-disable max-lines-per-function */
 
-const runScript = require('./run-script')
-const run = require('./run')
+const runScript = require('../run-script')
+const run = require('../run')
 
-jest.mock('./run')
+jest.mock('../run')
 
 const mockExecaResult = (props) => ({
   command: null,
@@ -86,7 +86,9 @@ describe('run-script', () => {
     expect(run).toHaveBeenCalledWith(
       'node',
       expect.arrayContaining([script.path, ...script.args]),
-      expect.objectContaining({ env: script.options.env })
+      expect.objectContaining({
+        env: expect.objectContaining(script.options.env),
+      })
     )
   })
 
@@ -105,7 +107,9 @@ describe('run-script', () => {
     expect(run).toHaveBeenCalledWith(
       'node',
       expect.arrayContaining([script.path, ...script.args]),
-      expect.objectContaining({ env: script.options.env })
+      expect.objectContaining({
+        env: expect.objectContaining(script.options.env),
+      })
     )
   })
 

--- a/lib/__tests__/run-scripts.test.js
+++ b/lib/__tests__/run-scripts.test.js
@@ -1,9 +1,9 @@
 'use strict'
 
-const runScript = require('./run-script')
-const runScripts = require('./run-scripts')
+const runScript = require('../run-script')
+const runScripts = require('../run-scripts')
 
-jest.mock('./run-script')
+jest.mock('../run-script')
 
 /** @type {Object} */
 const mockRunScript = runScript

--- a/lib/__tests__/run.integration.test.js
+++ b/lib/__tests__/run.integration.test.js
@@ -1,0 +1,40 @@
+'use strict'
+
+const run = require('../run')
+
+const exec = async (cmd, args, options) => {
+  const { all } = await run(cmd, args, {
+    all: true,
+    buffer: true,
+    stdio: 'pipe',
+    ...options,
+  })
+  return all
+}
+
+test('node -v', async () => {
+  const result = await exec('node', ['-v'])
+  expect(result).toEqual(expect.stringMatching('v[0-9.]+'))
+})
+
+test('overrides env values', async () => {
+  process.env.TEST123 = 'TEST123'
+  const result = await exec('printenv', ['TEST123'], {
+    env: {
+      TEST123: 'TEST456',
+    },
+  })
+  expect(result).toBe('TEST456')
+})
+
+test('preserves env precedence with process.env', async () => {
+  process.env.TEST123 = 'TEST123'
+  const result = await exec('printenv', ['TEST123'], {
+    env: {
+      TEST123: 'TEST456',
+      ...process.env,
+    },
+    extendEnv: false,
+  })
+  expect(result).toBe('TEST123')
+})

--- a/lib/__tests__/run.test.js
+++ b/lib/__tests__/run.test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const execa = require('execa')
-const run = require('./run')
+const run = require('../run')
 
 jest.mock('execa')
 

--- a/lib/__tests__/wire.run-scripts.commands.test.js
+++ b/lib/__tests__/wire.run-scripts.commands.test.js
@@ -1,9 +1,9 @@
 'use strict'
 
-const runScripts = require('./run-scripts')
-const wire = require('./wire')
+const runScripts = require('../run-scripts')
+const wire = require('../wire')
 
-jest.mock('./run-scripts')
+jest.mock('../run-scripts')
 
 /** @type {Object} */
 const mockRun = runScripts

--- a/lib/__tests__/wire.run-scripts.scripts.test.js
+++ b/lib/__tests__/wire.run-scripts.scripts.test.js
@@ -1,9 +1,9 @@
 'use strict'
 
-const runScripts = require('./run-scripts')
-const wire = require('./wire')
+const runScripts = require('../run-scripts')
+const wire = require('../wire')
 
-jest.mock('./run-scripts')
+jest.mock('../run-scripts')
 
 /** @type {Object} */
 const mockRunScripts = runScripts

--- a/lib/__tests__/wire.run.test.js
+++ b/lib/__tests__/wire.run.test.js
@@ -2,10 +2,10 @@
 
 /* eslint-disable max-lines-per-function */
 
-const run = require('./run')
-const wire = require('./wire')
+const run = require('../run')
+const wire = require('../wire')
 
-jest.mock('./run')
+jest.mock('../run')
 
 /** @type {Object} */
 const mockRun = run

--- a/lib/run-script.js
+++ b/lib/run-script.js
@@ -39,7 +39,13 @@ async function runScript({ name = '', path = '', args = [], options = {} }) {
   }
 
   time('start %s', name)
-  const result = await run('node', [...nodeArgs, path, ...args], { env })
+  const result = await run('node', [...nodeArgs, path, ...args], {
+    env: {
+      ...env,
+      ...process.env,
+    },
+    extendEnv: false,
+  })
   time('end %s', name)
 
   // Add line break between scripts


### PR DESCRIPTION
- Move tests to `__tests__`
- **Breaking change**: Environment variables in script configs no longer overwrite existing environment variables.