### PR TITLE
🔇 remove mergedOptions from debug logs

### DIFF
--- a/lib/run.js
+++ b/lib/run.js
@@ -25,7 +25,7 @@ function run(cmd, args = [], options = {}) {
   /** @type {object} */
   const mergedOptions = { ...defaultOptions, ...options }
 
-  debug('run %s %o %o', cmd, args, mergedOptions)
+  debug('run %s %o %o', cmd, args)
   return execa(cmd, args, mergedOptions)
 }
 


### PR DESCRIPTION
mergedOptions may include process.env, which may include sensitive info